### PR TITLE
Fix syntax errors in main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,7 +15,7 @@ import logging
 import uvicorn
 
 # Configure logging
-logger = logging.getLogger(__name    # Username, hash, and status are extracted above
+logger = logging.getLogger(__name__)
     print(f"Found user {username} with hash: {stored_hash} and status: {user_status}")
     
     # Verify password
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name    # Username, hash, and status are extracted 
             status_code=401,
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
-        }.setLevel(logging.INFO)
+        )
 handler = logging.StreamHandler()
 handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s | %(levelname)s: %(message)s')

--- a/fix_main.py
+++ b/fix_main.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Fix for the main.py file to correct syntax errors
+"""
+
+import os
+import sys
+
+def main():
+    main_py_path = "/home/hts/pj/komoot/backend/main.py"
+    
+    # Read the content of main.py
+    with open(main_py_path, "r") as f:
+        content = f.read()
+    
+    # Fix the logger initialization
+    content = content.replace(
+        "logger = logging.getLogger(__name    # Username, hash, and status are extracted above", 
+        "logger = logging.getLogger(__name__)"
+    )
+    
+    # Fix the HTTPException syntax error
+    content = content.replace(
+        """raise HTTPException(
+            status_code=401,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        }.setLevel(logging.INFO)""", 
+        """raise HTTPException(
+            status_code=401,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )"""
+    )
+    
+    # Write the corrected content back to main.py
+    with open(main_py_path, "w") as f:
+        f.write(content)
+    
+    print("Fixed syntax errors in main.py")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Corrected logger initialization to use the proper syntax.
- Fixed HTTPException raise statement to remove incorrect method chaining.
- Implemented a script to automate the fixes for future use.